### PR TITLE
feat(AuthClient): add OperationLogService integration

### DIFF
--- a/src/Contrib.Wasm/Masa.Contrib.StackSdks.Auth.Wasm/AuthClient.cs
+++ b/src/Contrib.Wasm/Masa.Contrib.StackSdks.Auth.Wasm/AuthClient.cs
@@ -19,6 +19,7 @@ public class AuthClient : IAuthClient
         ClientService = new ClientService(caller);
         DynamicRoleService = new DynamicRoleService(caller);
         UserClaimService = new UserClaimService(caller);
+        OperationLogService = new OperationLogService(caller);
     }
 
     public IUserService UserService { get; }
@@ -44,5 +45,7 @@ public class AuthClient : IAuthClient
     public IDynamicRoleService DynamicRoleService { get; }
 
     public IUserClaimService UserClaimService { get; }
+
+    public IOperationLogService OperationLogService { get; }
 }
 

--- a/src/Contrib.Wasm/Masa.Contrib.StackSdks.Auth.Wasm/Service/OperationLogService.cs
+++ b/src/Contrib.Wasm/Masa.Contrib.StackSdks.Auth.Wasm/Service/OperationLogService.cs
@@ -1,0 +1,19 @@
+﻿namespace Masa.Contrib.StackSdks.Auth.Wasm.Service;
+
+public class OperationLogService : IOperationLogService
+{
+    readonly ICaller _caller;
+
+    const string PARTY = "api/operationLog/";
+
+    public OperationLogService(ICaller caller)
+    {
+        _caller = caller;
+    }
+
+    public async Task AddLogAsync(AddOperationLogModel logModel)
+    {
+        var requestUri = $"{PARTY}add";
+        await _caller.PostAsync(requestUri, logModel);
+    }
+}


### PR DESCRIPTION
- Initialized `OperationLogService` in the `AuthClient` constructor.
- Added `IOperationLogService` property to `AuthClient` for accessing the operation log service.
- Implemented `OperationLogService` class in `OperationLogService.cs` with a constructor and an `AddLogAsync` method for asynchronous log addition.