### PR TITLE
Add GetI18NConfigByClientIdAsync method to IGlobalNavService and impl…

### DIFF
--- a/src/BuildingBlocks/Masa.BuildingBlocks.StackSdks.Sapp/Service/IGlobalNavService.cs
+++ b/src/BuildingBlocks/Masa.BuildingBlocks.StackSdks.Sapp/Service/IGlobalNavService.cs
@@ -10,4 +10,6 @@ public interface IGlobalNavService
     Task<List<GlobalNavigationNodeDto>> GetMenusByPmIdentityAsync(string pmIdentity);
 
     Task<List<AppEntryDto>> GetVisibleAppEntriesByClientIdAsync(string clientId);
+
+    Task<Dictionary<string, string>> GetI18NConfigByClientIdAsync(string clientId, string culture);
 }

--- a/src/Contrib.Wasm/Masa.Contrib.StackSdks.Sapp.Wasm/Service/GlobalNavService.cs
+++ b/src/Contrib.Wasm/Masa.Contrib.StackSdks.Sapp.Wasm/Service/GlobalNavService.cs
@@ -34,4 +34,11 @@ public class GlobalNavService : IGlobalNavService
         var result = await _caller.GetAsync<List<AppEntryDto>>(requestUri);
         return result ?? new();
     }
+
+    public async Task<Dictionary<string, string>> GetI18NConfigByClientIdAsync(string clientId, string culture)
+    {
+        var requestUri = $"{GLOBAL_NAV_ROUTE_PREFIX}/i18n-config/by-client-id/{clientId}?culture={culture}";
+        var result = await _caller.GetAsync<Dictionary<string, string>>(requestUri);
+        return result ?? new();
+    }
 }

--- a/src/Contrib/Masa.Contrib.StackSdks.Sapp/Service/GlobalNavService.cs
+++ b/src/Contrib/Masa.Contrib.StackSdks.Sapp/Service/GlobalNavService.cs
@@ -34,4 +34,11 @@ public class GlobalNavService : IGlobalNavService
         var result = await _caller.GetAsync<List<AppEntryDto>>(requestUri);
         return result ?? new();
     }
+
+    public async Task<Dictionary<string, string>> GetI18NConfigByClientIdAsync(string clientId, string culture)
+    {
+        var requestUri = $"{GLOBAL_NAV_ROUTE_PREFIX}/i18n-config/by-client-id/{clientId}?culture={culture}";
+        var result = await _caller.GetAsync<Dictionary<string, string>>(requestUri);
+        return result ?? new();
+    }
 }

--- a/src/Contrib/Tests/Masa.Contrib.StackSdks.Sapp.Tests/GlobalNavServiceTest.cs
+++ b/src/Contrib/Tests/Masa.Contrib.StackSdks.Sapp.Tests/GlobalNavServiceTest.cs
@@ -107,4 +107,38 @@ public class GlobalNavServiceTest
 
         Assert.AreEqual(0, result.Count);
     }
+
+    [TestMethod]
+    [DataRow("MASA_STACK", "zh-CN")]
+    public async Task TestGetI18NConfigByClientIdAsync(string clientId, string culture)
+    {
+        var data = new Dictionary<string, string> { { "key", "value" } };
+
+        var requestUri = $"api/global-nav/i18n-config/by-client-id/{clientId}?culture={culture}";
+        var caller = new Mock<ICaller>();
+        caller.Setup(provider => provider.GetAsync<Dictionary<string, string>>(requestUri, default)).ReturnsAsync(data).Verifiable();
+        var sappClient = new SappClient(caller.Object);
+
+        var result = await sappClient.GlobalNavService.GetI18NConfigByClientIdAsync(clientId, culture);
+        caller.Verify(provider => provider.GetAsync<Dictionary<string, string>>(requestUri, default), Times.Once);
+
+        Assert.AreEqual(1, result.Count);
+    }
+
+    [TestMethod]
+    [DataRow("MASA_STACK", "zh-CN")]
+    public async Task TestGetI18NConfigByClientIdWhenNullAsync(string clientId, string culture)
+    {
+        Dictionary<string, string>? data = null;
+
+        var requestUri = $"api/global-nav/i18n-config/by-client-id/{clientId}?culture={culture}";
+        var caller = new Mock<ICaller>();
+        caller.Setup(provider => provider.GetAsync<Dictionary<string, string>>(It.IsAny<string>(), default)).ReturnsAsync(data).Verifiable();
+        var sappClient = new SappClient(caller.Object);
+
+        var result = await sappClient.GlobalNavService.GetI18NConfigByClientIdAsync(clientId, culture);
+        caller.Verify(provider => provider.GetAsync<Dictionary<string, string>>(requestUri, default), Times.Once);
+
+        Assert.AreEqual(0, result.Count);
+    }
 }


### PR DESCRIPTION
…ement in GlobalNavService

- Introduced GetI18NConfigByClientIdAsync method in IGlobalNavService to fetch internationalization configuration based on client ID and culture.
- Implemented the method in GlobalNavService with appropriate API call.
- Added unit tests to validate the new functionality, including scenarios for valid and null responses.