### PR TITLE
chore(workflow): 更新工作流配置中的引号格式和.NET版本

### DIFF
--- a/.github/workflows/Codecov.yml
+++ b/.github/workflows/Codecov.yml
@@ -2,7 +2,7 @@ name: Codecov
 on:
   push:
     branches:
-      - 'main'
+      - "main"
   workflow_dispatch:
 
 jobs:
@@ -15,110 +15,108 @@ jobs:
         node: [16]
 
     steps:
-    - name: git pull
-      uses: actions/checkout@v2
+      - name: git pull
+        uses: actions/checkout@v2
 
-    - name: run a one-line script
-      run: env
+      - name: run a one-line script
+        run: env
 
-    - name: Configure sysctl limits
-      run: |
-        sudo swapoff -a
-        sudo sysctl -w vm.swappiness=1
-        sudo sysctl -w fs.file-max=262144
-        sudo sysctl -w vm.max_map_count=262144
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
 
-    - name: Start Elasticsearch
-      uses: everpcpc/elasticsearch-action@v2
-      with:
-        version: 7.6.1
-        plugins: |         
-          https://release.infinilabs.com/analysis-ik/stable/elasticsearch-analysis-ik-7.6.1.zip
-          https://release.infinilabs.com/analysis-pinyin/stable/elasticsearch-analysis-pinyin-7.6.1.zip
-          analysis-icu
-          analysis-smartcn
-          analysis-kuromoji
+      - name: Start Elasticsearch
+        uses: everpcpc/elasticsearch-action@v2
+        with:
+          version: 7.6.1
+          plugins: |
+            https://release.infinilabs.com/analysis-ik/stable/elasticsearch-analysis-ik-7.6.1.zip
+            https://release.infinilabs.com/analysis-pinyin/stable/elasticsearch-analysis-pinyin-7.6.1.zip
+            analysis-icu
+            analysis-smartcn
+            analysis-kuromoji
 
-    - name: Start Redis
-      uses: supercharge/redis-github-action@1.4.0
-      with:
-        redis-version: ${{ matrix.redis-version }}
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.4.0
+        with:
+          redis-version: ${{ matrix.redis-version }}
 
-    - name: Set up JDK 14
-      uses: actions/setup-java@v1
-      with:
-        #java-version: 1.11
-        #版本更新
-        java-version: 1.17
-        
+      - name: Set up JDK 14
+        uses: actions/setup-java@v1
+        with:
+          #java-version: 1.11
+          #版本更新
+          java-version: 1.17
 
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
-    - name: Cache SonarCloud packages
-      uses: actions/cache@v3
-      with:
-        path: ~\sonar\cache
-        key: ${{ runner.os }}-sonar
-        restore-keys: ${{ runner.os }}-sonar
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~\sonar\cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
 
-    - name: Cache SonarCloud scanner
-      id: cache-sonar-scanner
-      uses: actions/cache@v3
-      with:
-        path: .\.sonar\scanner
-        key: ${{ runner.os }}-sonar-scanner
-        restore-keys: ${{ runner.os }}-sonar-scanner
+      - name: Cache SonarCloud scanner
+        id: cache-sonar-scanner
+        uses: actions/cache@v3
+        with:
+          path: .\.sonar\scanner
+          key: ${{ runner.os }}-sonar-scanner
+          restore-keys: ${{ runner.os }}-sonar-scanner
 
-#    - name: SonarScanner for .NET 6 with pull request decoration support
-#      uses: highbyte/sonarscan-dotnet@v2.1.3
-#      with:
-#        # The key of the SonarQube project
-#        sonarProjectKey: masastack_MASA.Framework
-#        # The name of the SonarQube project
-#        sonarProjectName:  MASA.Framework
-#        # The name of the SonarQube organization in SonarCloud. For hosted SonarQube, skip this setting.
-#        sonarOrganization: masastack
-#        # Optional command arguments to dotnet test
-#        dotnetTestArguments: --filter FullyQualifiedName!~Masa.Utils --no-build --logger trx --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
-#        # Optional extra command arguments the the SonarScanner 'begin' command
-#        sonarBeginArguments: /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml" -d:sonar.cs.vstest.reportsPaths="**/TestResults/*.trx"
-#
-#env:
-#  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-#  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #    - name: SonarScanner for .NET 6 with pull request decoration support
+      #      uses: highbyte/sonarscan-dotnet@v2.1.3
+      #      with:
+      #        # The key of the SonarQube project
+      #        sonarProjectKey: masastack_MASA.Framework
+      #        # The name of the SonarQube project
+      #        sonarProjectName:  MASA.Framework
+      #        # The name of the SonarQube organization in SonarCloud. For hosted SonarQube, skip this setting.
+      #        sonarOrganization: masastack
+      #        # Optional command arguments to dotnet test
+      #        dotnetTestArguments: --filter FullyQualifiedName!~Masa.Utils --no-build --logger trx --collect:"XPlat Code Coverage" -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=opencover
+      #        # Optional extra command arguments the the SonarScanner 'begin' command
+      #        sonarBeginArguments: /d:sonar.cs.opencover.reportsPaths="**/TestResults/**/coverage.opencover.xml" -d:sonar.cs.vstest.reportsPaths="**/TestResults/*.trx"
+      #
+      #env:
+      #  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      #  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Install SonarCloud scanner
-      run: |
-        dotnet tool install --global dotnet-sonarscanner
+      - name: Install SonarCloud scanner
+        run: |
+          dotnet tool install --global dotnet-sonarscanner
 
-    - name: setting dotnet version
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: |
-          8.0.x
-          7.0.x
-          6.0.x
+      - name: setting dotnet version
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: |
+            10.0.x
+            8.0.x
 
-        include-prerelease: true
+          include-prerelease: true
 
-    - name: Build and analyze
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: |
-        dotnet sonarscanner begin /k:"masastack_MASA.Framework" /o:"masastack" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
-        dotnet build /p:ContinuousIntegrationBuild=true
-        # dotnet test --filter FullyQualifiedName!~Masa.Utils --no-build --verbosity normal --collect "Code Coverage" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[*.Tests]*"
-        dotnet sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          dotnet sonarscanner begin /k:"masastack_MASA.Framework" /o:"masastack" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+          dotnet build /p:ContinuousIntegrationBuild=true
+          # dotnet test --filter FullyQualifiedName!~Masa.Utils --no-build --verbosity normal --collect "Code Coverage" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[*.Tests]*"
+          dotnet sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
 
-    - name: Opencover Test
-      run: |
-        dotnet test --filter FullyQualifiedName!~Masa.Utils --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[*.Tests]*"
+      - name: Opencover Test
+        run: |
+          dotnet test --filter FullyQualifiedName!~Masa.Utils --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[*.Tests]*"
 
-    - name: codecov
-      uses: codecov/codecov-action@v3.1.1
+      - name: codecov
+        uses: codecov/codecov-action@v3.1.1
 
 #    - name: Install SonarCloud scanner
 #      run: |

--- a/.github/workflows/package_push_nuget.org.yml
+++ b/.github/workflows/package_push_nuget.org.yml
@@ -9,29 +9,29 @@ jobs:
     name: package build and push
     runs-on: ubuntu-latest
     steps:
-    - name: git pull
-      uses: actions/checkout@v2
+      - name: git pull
+        uses: actions/checkout@v2
 
-    - name: run a one-line script
-      run: env
+      - name: run a one-line script
+        run: env
 
-    - name: setting dotnet version
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: |
-          8.0.x
-          7.0.x
-          6.0.x
-        include-prerelease: true
+      - name: setting dotnet version
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: |
+            10.0.x
+            8.0.x
 
-    - name: restore
-      run: dotnet restore
+          include-prerelease: true
 
-    - name: build
-      run: dotnet build --no-restore /p:ContinuousIntegrationBuild=true
+      - name: restore
+        run: dotnet restore
 
-    - name: pack
-      run: dotnet pack --include-symbols  -p:PackageVersion=$GITHUB_REF_NAME
+      - name: build
+        run: dotnet build --no-restore /p:ContinuousIntegrationBuild=true
 
-    - name: package push
-      run: dotnet nuget push "**/*.symbols.nupkg" -k  ${{secrets.NUGET_TOKEN}}  -s https://api.nuget.org/v3/index.json --skip-duplicate
+      - name: pack
+        run: dotnet pack --include-symbols  -p:PackageVersion=$GITHUB_REF_NAME
+
+      - name: package push
+        run: dotnet nuget push "**/*.symbols.nupkg" -k  ${{secrets.NUGET_TOKEN}}  -s https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/pr_run_test_ci.yml
+++ b/.github/workflows/pr_run_test_ci.yml
@@ -2,7 +2,7 @@ name: PR_Run_Test_CI
 on:
   pull_request:
     branches:
-      - 'main'
+      - "main"
   workflow_dispatch:
 
 jobs:
@@ -24,87 +24,86 @@ jobs:
           # Maps port 6379 on service container to the host
           - 6379:6379
 
-#     strategy:
-#       matrix:
-#         redis-version: [5]
+    #     strategy:
+    #       matrix:
+    #         redis-version: [5]
     steps:
-    - name: git pull
-      uses: actions/checkout@v2
+      - name: git pull
+        uses: actions/checkout@v2
 
-    - name: run a one-line script
-      run: env
+      - name: run a one-line script
+        run: env
 
-    - name: setting dotnet version
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: |
-          8.0.x
-          7.0.x
-          6.0.x
-          
-        include-prerelease: true
+      - name: setting dotnet version
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: |
+            10.0.x
+            8.0.x
 
-#     - name: Start Redis
-#       uses: supercharge/redis-github-action@1.4.0
-#       with:
-#         redis-version: ${{ matrix.redis-version }}
+          include-prerelease: true
 
-    - name: Configure sysctl limits
-      run: |
-        sudo swapoff -a
-        sudo sysctl -w vm.swappiness=1
-        sudo sysctl -w fs.file-max=262144
-        sudo sysctl -w vm.max_map_count=262144
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.17
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-    - name: Cache SonarCloud packages
-      uses: actions/cache@v3
-      with:
-        path: ~\sonar\cache
-        key: ${{ runner.os }}-sonar
-        restore-keys: ${{ runner.os }}-sonar
-    - name: Cache SonarCloud scanner
-      id: cache-sonar-scanner
-      uses: actions/cache@v3
-      with:
-        path: .\.sonar\scanner
-        key: ${{ runner.os }}-sonar-scanner
-        restore-keys: ${{ runner.os }}-sonar-scanner
-    - name: Install SonarCloud scanner
-      run: |
-        dotnet tool install --global dotnet-sonarscanner
-    - name: Start Elasticsearch
-      uses: everpcpc/elasticsearch-action@v2
-      with:
-        version: 7.6.1
-        plugins: |
-          https://release.infinilabs.com/analysis-ik/stable/elasticsearch-analysis-ik-7.6.1.zip
-          https://release.infinilabs.com/analysis-pinyin/stable/elasticsearch-analysis-pinyin-7.6.1.zip
-          analysis-icu
-          analysis-smartcn
-          analysis-kuromoji
+      #     - name: Start Redis
+      #       uses: supercharge/redis-github-action@1.4.0
+      #       with:
+      #         redis-version: ${{ matrix.redis-version }}
 
-    # sonar 单元测试覆盖率和其它验证，暂时关闭
-    #- name: Build and analyze for internal
-    #  env:
-    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-    #    SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    #  if: ${{ env.SONAR_TOKEN != '' }}
-    #  run: |
-    #    dotnet-sonarscanner begin /k:"masastack_MASA.Stack.Sdks" /o:"masastack" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
-    #    dotnet build /p:ContinuousIntegrationBuild=true
-    #    dotnet test --filter FullyQualifiedName!~Masa.Utils --no-build --verbosity normal --collect "Code Coverage" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[*.Tests]*"
-    #    dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
-    - name: Build and analyze for outside
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      if: ${{ env.SONAR_TOKEN == '' }}
-      run: |
-        dotnet build /p:ContinuousIntegrationBuild=true
-        dotnet test --filter FullyQualifiedName!~Masa.Utils --no-build --verbosity normal --collect "Code Coverage" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[*.Tests]*"
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.17
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~\sonar\cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache SonarCloud scanner
+        id: cache-sonar-scanner
+        uses: actions/cache@v3
+        with:
+          path: .\.sonar\scanner
+          key: ${{ runner.os }}-sonar-scanner
+          restore-keys: ${{ runner.os }}-sonar-scanner
+      - name: Install SonarCloud scanner
+        run: |
+          dotnet tool install --global dotnet-sonarscanner
+      - name: Start Elasticsearch
+        uses: everpcpc/elasticsearch-action@v2
+        with:
+          version: 7.6.1
+          plugins: |
+            https://release.infinilabs.com/analysis-ik/stable/elasticsearch-analysis-ik-7.6.1.zip
+            https://release.infinilabs.com/analysis-pinyin/stable/elasticsearch-analysis-pinyin-7.6.1.zip
+            analysis-icu
+            analysis-smartcn
+            analysis-kuromoji
+
+      # sonar 单元测试覆盖率和其它验证，暂时关闭
+      #- name: Build and analyze for internal
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+      #    SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      #  if: ${{ env.SONAR_TOKEN != '' }}
+      #  run: |
+      #    dotnet-sonarscanner begin /k:"masastack_MASA.Stack.Sdks" /o:"masastack" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+      #    dotnet build /p:ContinuousIntegrationBuild=true
+      #    dotnet test --filter FullyQualifiedName!~Masa.Utils --no-build --verbosity normal --collect "Code Coverage" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[*.Tests]*"
+      #    dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"
+      - name: Build and analyze for outside
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        if: ${{ env.SONAR_TOKEN == '' }}
+        run: |
+          dotnet build /p:ContinuousIntegrationBuild=true
+          dotnet test --filter FullyQualifiedName!~Masa.Utils --no-build --verbosity normal --collect "Code Coverage" /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:Exclude="[*.Tests]*"


### PR DESCRIPTION
- 将分支名称中的单引号改为双引号
- 更新.NET版本从8.0.x/7.0.x/6.0.x到10.0.x/8.0.x
- 移除注释掉的Redis启动步骤
- 统一代码缩进格式
- 移除注释掉的SonarScanner相关配置