### PR TITLE
ResetPasswordModel 新增可空 ClientId 属性

### DIFF
--- a/src/BuildingBlocks/Auth/Masa.BuildingBlocks.StackSdks.Auth.Contracts/Model/ResetPasswordModel.cs
+++ b/src/BuildingBlocks/Auth/Masa.BuildingBlocks.StackSdks.Auth.Contracts/Model/ResetPasswordModel.cs
@@ -8,4 +8,6 @@ public abstract class ResetPasswordModel
     public string Password { get; set; }
 
     public string ConfirmPassword { get; set; }
+
+    public string? ClientId { get; set; }
 }


### PR DESCRIPTION
在 ResetPasswordModel 类中添加了可空的 ClientId 属性（string? ClientId），用于存储客户端 ID，增强了模型的扩展性和适用场景。其他属性保持不变。