### PR TITLE
为邮件与短信模型添加ClientId属性

### DIFF
--- a/src/BuildingBlocks/Auth/Masa.BuildingBlocks.StackSdks.Auth.Contracts/Model/SendEmailModel.cs
+++ b/src/BuildingBlocks/Auth/Masa.BuildingBlocks.StackSdks.Auth.Contracts/Model/SendEmailModel.cs
@@ -11,6 +11,8 @@ public class SendEmailModel : IEnvironmentModel
 
     public string Environment { get; set; }
 
+    public string? ClientId { get; set; }
+
     public SendEmailModel()
     {
     }

--- a/src/BuildingBlocks/Auth/Masa.BuildingBlocks.StackSdks.Auth.Contracts/Model/SendMsgCodeModel.cs
+++ b/src/BuildingBlocks/Auth/Masa.BuildingBlocks.StackSdks.Auth.Contracts/Model/SendMsgCodeModel.cs
@@ -13,6 +13,8 @@ public class SendMsgCodeModel : IEnvironmentModel
 
     public string Environment { get; set; }
 
+    public string? ClientId { get; set; }
+
     public SendMsgCodeModel()
     {
     }


### PR DESCRIPTION
在 SendEmailModel 和 SendMsgCodeModel 类中新增可空字符串属性 ClientId，用于存储客户端ID，便于后续扩展和客户端标识。其他代码保持不变。